### PR TITLE
Add dynamic placeholder replacement in functions.tmdl

### DIFF
--- a/.github/workflows/publish-abcclassification.yml
+++ b/.github/workflows/publish-abcclassification.yml
@@ -99,6 +99,14 @@ jobs:
       - name: Copy package files
         run: cp -rv source-repo/src/${{ env.DAXPATTERN_NAME }}/* "fork-repo/${{ steps.package.outputs.folder }}/"
 
+      # Replace the package ID and version placeholders in functions.tmdl
+      - name: Replace placeholders
+        working-directory: fork-repo
+        run: |
+          FUNCTIONS_FILE="${{ steps.package.outputs.folder }}/lib/functions.tmdl"
+          sed -i "s/__PLACEHOLDER_DAXLIB_PACKAGEID__/${{ steps.package.outputs.name }}/g" "${FUNCTIONS_FILE}"
+          sed -i "s/__PLACEHOLDER_DAXLIB_PACKAGEVERSION__/${{ steps.package.outputs.version }}/g" "${FUNCTIONS_FILE}"
+
       # Commit changes. If there are no changes, this will fail and stop the workflow
       - name: Git commit changes
         working-directory: fork-repo

--- a/src/AbcClassification/lib/functions.tmdl
+++ b/src/AbcClassification/lib/functions.tmdl
@@ -36,9 +36,9 @@ function 'DaxPatterns.AbcClassification.ComputeInAbcClass' = ```
                 )
             RETURN Result
         ```
-    annotation DAXLIB_PackageId = DaxPatterns.AbcClassification
+    annotation DAXLIB_PackageId = __PLACEHOLDER_PACKAGE_ID__
 
-    annotation DAXLIB_PackageVersion = 0.1.3
+    annotation DAXLIB_PackageVersion = __PLACEHOLDER_PACKAGE_VERSION__
 
 /// Return the items filtered by ABC classes
 /// Implement Dynamic ABC Classification pattern from DAX Patterns
@@ -110,6 +110,6 @@ function 'DaxPatterns.AbcClassification.ItemsInClass' = ```
                 )
             RETURN Result
         ```
-    annotation DAXLIB_PackageId = DaxPatterns.AbcClassification
+    annotation DAXLIB_PackageId = __PLACEHOLDER_PACKAGE_ID__
 
-    annotation DAXLIB_PackageVersion = 0.1.3
+    annotation DAXLIB_PackageVersion = __PLACEHOLDER_PACKAGE_VERSION__


### PR DESCRIPTION
Introduce a new workflow step in `publish-abcclassification.yml` to replace placeholders for package ID and version in the `functions.tmdl` file. Updated `functions.tmdl` to use placeholders (`__PLACEHOLDER_PACKAGE_ID__` and
`__PLACEHOLDER_PACKAGE_VERSION__`) instead of hardcoded values for `DAXLIB_PackageId` and `DAXLIB_PackageVersion`. This ensures metadata is dynamically updated during workflow execution.