### PR TITLE
Fixup placeholder names in publish workflow

### DIFF
--- a/.github/workflows/publish-abcclassification.yml
+++ b/.github/workflows/publish-abcclassification.yml
@@ -104,8 +104,8 @@ jobs:
         working-directory: fork-repo
         run: |
           FUNCTIONS_FILE="${{ steps.package.outputs.folder }}/lib/functions.tmdl"
-          sed -i "s/__PLACEHOLDER_DAXLIB_PACKAGEID__/${{ steps.package.outputs.name }}/g" "${FUNCTIONS_FILE}"
-          sed -i "s/__PLACEHOLDER_DAXLIB_PACKAGEVERSION__/${{ steps.package.outputs.version }}/g" "${FUNCTIONS_FILE}"
+          sed -i "s/__PLACEHOLDER_PACKAGE_ID__/${{ steps.package.outputs.name }}/g" "${FUNCTIONS_FILE}"
+          sed -i "s/__PLACEHOLDER_PACKAGE_VERSION__/${{ steps.package.outputs.version }}/g" "${FUNCTIONS_FILE}"
 
       # Commit changes. If there are no changes, this will fail and stop the workflow
       - name: Git commit changes


### PR DESCRIPTION
This pull request makes a small update to the workflow file `.github/workflows/publish-abcclassification.yml` by changing the placeholder names used in the `functions.tmdl` file to more general terms.

* Updated the `sed` commands to replace `__PLACEHOLDER_DAXLIB_PACKAGEID__` and `__PLACEHOLDER_DAXLIB_PACKAGEVERSION__` with `__PLACEHOLDER_PACKAGE_ID__` and `__PLACEHOLDER_PACKAGE_VERSION__` respectively in the `functions.tmdl` file.