### PR TITLE
Fix README snippets, add project/repo URLs in manifest, bump 0.1.4

### DIFF
--- a/src/AbcClassification/README.md
+++ b/src/AbcClassification/README.md
@@ -18,7 +18,7 @@ DaxPatterns.AbcClassification.ComputeInAbcClass (
     <itemKeyColumn>,           -- e.g., 'Product'[ProductKey]
     <abcClassTable>,           -- e.g., 'ABC Classes' (disconnected)
     <abcLowerBoundaryColumn>,  -- e.g., 'ABC Classes'[Lower Boundary]  -- inclusive
-    <abcUpperBoundaryColumn]   -- e.g., 'ABC Classes'[Upper Boundary]  -- exclusive (see notes)
+    <abcUpperBoundaryColumn>   -- e.g., 'ABC Classes'[Upper Boundary]  -- exclusive (see notes)
 )
 ```
 
@@ -75,7 +75,6 @@ DaxPatterns.AbcClassification.ComputeInAbcClass (
     'ABC Classes'[Lower Boundary], 
     'ABC Classes'[Upper Boundary]
 )
-
 ```
 
 These produce a **dynamic** ABC where class membership updates with filters (e.g., year, region).

--- a/src/AbcClassification/README.md
+++ b/src/AbcClassification/README.md
@@ -11,7 +11,7 @@ Functions to implement the [ABC Classification](https://www.daxpatterns.com/abc-
 ## Function
 
 ```DAX
-ComputeInAbcClass (
+DaxPatterns.AbcClassification.ComputeInAbcClass (
     <valueExpr>,               -- e.g., [Sales Amount] (must be additive, SUM-based)
     <transactionsTable>,       -- e.g., Sales
     <itemTable>,               -- e.g., 'Product'
@@ -66,7 +66,7 @@ This matches the pattern described in DAX Patterns and its dynamic variant (clas
 
 ```DAX
 ABC Sales Amount =
-ComputeInAbcClass (
+DaxPatterns.AbcClassification.ComputeInAbcClass (
     [Sales Amount],
     Sales,
     'Product',

--- a/src/AbcClassification/manifest.daxlib
+++ b/src/AbcClassification/manifest.daxlib
@@ -4,6 +4,9 @@
   "version": "0.1.3",
   "authors": "SQLBI",
   "description": "Implementation of ABC Classification patterns using User Defined Functions.",
+  "releaseNotes": "Documentation update only; no functional changes.",
+  "projectUrl": "https://www.daxpatterns.com",
+  "repositoryUrl": "https://github.com/sql-bi/dev-daxpatterns",
   "tags": "DAX,UDF,FUNCTION,LIB,PATTERN,ABC",
   "icon": "/icon.png",
   "readme": "/README.md"

--- a/src/AbcClassification/manifest.daxlib
+++ b/src/AbcClassification/manifest.daxlib
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/daxlib/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
   "id": "DaxPatterns.AbcClassification",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "authors": "SQLBI",
   "description": "Implementation of ABC Classification patterns using User Defined Functions.",
   "releaseNotes": "Documentation update only; no functional changes.",


### PR DESCRIPTION
Fixes https://github.com/daxlib/daxlib/issues/135

This pull request updates the documentation for the ABC Classification DAX library for the `ComputeInAbcClass` function by specifying its fully qualified name. It also updates the library manifest with new metadata and increments the version to reflect these documentation changes. No functional changes to the code have been made.

Documentation improvements:

* Updated all references to the `ComputeInAbcClass` function in `README.md` to use the fully qualified name `DaxPatterns.AbcClassification.ComputeInAbcClass`. [[1]](diffhunk://#diff-8f0d3300c4cf54ea31ba72004ef3842712574f56bd578f9572bce9ab757b7db8L14-R21) [[2]](diffhunk://#diff-8f0d3300c4cf54ea31ba72004ef3842712574f56bd578f9572bce9ab757b7db8L69-R69)
* Fixed a typo in the function signature example by correcting a misplaced bracket.

Manifest updates:

* Incremented the version in `manifest.daxlib` to `0.1.4` and added release notes indicating documentation-only changes.
* Added `projectUrl` and `repositoryUrl` fields to the manifest for improved discoverability.